### PR TITLE
Fix header paths

### DIFF
--- a/src/mDNSResolver.cpp
+++ b/src/mDNSResolver.cpp
@@ -1,4 +1,4 @@
-#include "mDNSResolver/mDNSResolver.h"
+#include "mDNSResolver.h"
 #include "Arduino.h"
 #include "Particle.h"
 

--- a/src/mDNSResolver.h
+++ b/src/mDNSResolver.h
@@ -4,9 +4,9 @@
 // #include <mDNSResolver/IPAddress.h>
 // #include <WiFiUDP.h>
 #include "Particle.h"
-#include "mDNSResolver/Cache.h"
-#include "mDNSResolver/Query.h"
-#include "mDNSResolver/Answer.h"
+#include "./Cache.h"
+#include "./Query.h"
+#include "./Answer.h"
 
 #define MDNS_BROADCAST_IP IPAddress(224, 0, 0, 251)
 #define MDNS_PORT         5353


### PR DESCRIPTION
This change tweaks the paths of several `#include` entries to match what is checked into the project, allowing it to compile.